### PR TITLE
Loop on rdrand flag return

### DIFF
--- a/rdrand.asm
+++ b/rdrand.asm
@@ -8,13 +8,21 @@
     ; Generated some polemic when kernel devs wanted to use it as part of `/dev/random`,
     ; because it could be used as a cryptographic backdoor by Intel since it is a black box.
 
+    ; rdrand sets the carry flag when data is ready; one must loop if
+    ; the carry flag isn't set, but unlike in this example, one should
+    ; bound the number of attempts.
+
 %include "lib/asm_io.inc"
 
 ENTRY
+.loop0:
     rdrand eax
+    jnc .loop0
     call print_int
 
+.loop1:
     rdrand eax
+    jnc .loop1
     call print_int
 
     EXIT


### PR DESCRIPTION
According to the Intel instruction set reference manual, we need to
check the carry flag after calling rdrand, and loop if it's not set.
